### PR TITLE
Fix for snackbar sometimes displaying in upper left of screen.

### DIFF
--- a/snackbar/src/main/java/com/github/mrengineer13/snackbar/SnackContainer.java
+++ b/snackbar/src/main/java/com/github/mrengineer13/snackbar/SnackContainer.java
@@ -38,7 +38,7 @@ class SnackContainer extends FrameLayout {
 
         setId(R.id.snackContainer);
         setVisibility(View.GONE);
-        container.addView(this);
+        container.addView(this, new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
 
         mInAnimationSet = new AnimationSet(false);
 


### PR DESCRIPTION
Something that I noticed on a tablet when I brought in 0.4.1. My bad.
