### PR TITLE
Fix: the new snack bar hide too quick if clear previous snacks.

### DIFF
--- a/snackbar/src/main/java/com/github/mrengineer13/snackbar/SnackContainer.java
+++ b/snackbar/src/main/java/com/github/mrengineer13/snackbar/SnackContainer.java
@@ -134,6 +134,7 @@ class SnackContainer extends FrameLayout {
 
     public void clearSnacks(boolean animate) {
         mSnacks.clear();
+        removeCallbacks(mHideRunnable);
         if (animate) mHideRunnable.run();
     }
 


### PR DESCRIPTION
Hi, I have a fix when I using your library. The details is showing below. If I misunderstand your intention of this method, please let me know. And I'll be happy to hear if there is a better way to accomplish the work described in Background.
Thank you. ^_^

- Background
When we need to show a bunch of toast one by one (eg, continuous remove
email), we don't want to have a delay between previous toast and latest
one. So we can clear previous snacks before show new one (by the API
SnackBar.clear).

- Cause
mHideRunnable contains no context of snacks, postDelay runnable of
previous snack will affect latter snack. If we clear snacks without
remove there postDelay callbacks, the latter added snack will hide
quickly by receive callback of previous snack.

- Fix
A simple fix is remove the callbacks of mHideRunnable when clear. This
logic is also seem in other part of SnackContainer (like 'hide' and
'onTouch').